### PR TITLE
Added Fan Support 

### DIFF
--- a/models/fan.ts
+++ b/models/fan.ts
@@ -1,0 +1,24 @@
+import { BaseDevice } from './device';
+import { OnOffState } from './states/onoff';
+import { FanSpeedModeState, availableFanSpeedModes } from './states/fanspeedmode';
+import { FanSpeedPercentState } from './states/fanspeedpercent';
+
+type FanBase =  BaseDevice & {
+    type: 'fan';
+    availableFanSpeeds: availableFanSpeedModes;
+    reversible: false;
+    supportsFanSpeedPercent: false;
+    commandOnlyFanSpeed: false;
+    state: OnOffState & FanSpeedModeState;
+}
+
+type FanDeviceWithFanSpeedPercent = BaseDevice & {
+    type: 'fan';
+    availableFanSpeeds: availableFanSpeedModes;
+    reversible: false;
+    supportsFanSpeedPercent: true;
+    commandOnlyFanSpeed: false;
+    state: OnOffState & FanSpeedModeState & FanSpeedPercentState;
+}
+
+export type FanDevice = FanBase | FanDeviceWithFanSpeedPercent;

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,4 +1,5 @@
 import { BlindsDevice } from './blinds';
+import { FanDevice } from './fan';
 import { GarageDevice } from './garage';
 import { LightDevice } from './light';
 import { LockDevice } from './lock';
@@ -14,7 +15,7 @@ export interface Devices {
 }
 
 export type Device = SwitchDevice | LightDevice | SceneDevice | OutletDevice | ThermostatDevice |
-    SpeakerDevice | BlindsDevice | GarageDevice | LockDevice | VacuumDevice;
+    SpeakerDevice | BlindsDevice | GarageDevice | LockDevice | VacuumDevice | FanDevice;
 
 export type AllStates = Device['state'];
 

--- a/models/states/fanspeedmode.ts
+++ b/models/states/fanspeedmode.ts
@@ -1,0 +1,41 @@
+import { State } from './state';
+
+export type availableFanSpeedModes = {
+    'speeds': [
+    {
+        'speed_name': 'S1',
+        'speed_values': [{
+            'speed_synonym': ['low', 'speed 1'],
+            'lang': 'en'
+        }]
+    },
+    {
+        'speed_name': 'S2',
+        'speed_values': [{
+            'speed_synonym': ['medium', 'speed 2'],
+            'lang': 'en'
+        }]
+    },
+    {
+        'speed_name': 'S3',
+        'speed_values': [{
+            'speed_synonym': ['high', 'speed 3'],
+            'lang': 'en'
+        }]
+    },
+    {
+        'speed_name': 'S4',
+        'speed_values': [{
+            'speed_synonym': ['max', 'speed 4'],
+            'lang': 'en'
+        }]
+    }
+    ],
+    'ordered': true
+}
+
+export type FanSpeedMode = 'S1' | 'S2' | 'S3' | 'S4';
+
+export interface FanSpeedModeState extends State {
+     currentFanSpeedSetting: FanSpeedMode;
+}

--- a/models/states/fanspeedpercent.ts
+++ b/models/states/fanspeedpercent.ts
@@ -1,0 +1,9 @@
+import { State } from './state';
+
+export interface FanSpeedPercentState extends State {
+    /**
+     * @minimum 0
+     * @maximum 100
+     */
+    currentFanSpeedPercent: number;
+}


### PR DESCRIPTION
As Per issue 7: andrei-tatar/node-red-contrib-nora#7

We are adding fan support.

This adds support for fans with 4 speed modes, and percentage based fan speeds.

It does not support fans that are reversible.

It includes a node js test service that can be used to verify that fans are working.

I created a full test environment and verified that all google fan control commands were working as intended.

Depends on: https://github.com/andrei-tatar/nora-service/pull/34